### PR TITLE
Add a keyboard shortcut (Command + Q on Mac or Control + Q on other OS) to Quit the app directly. Fixes #12422

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -917,6 +917,11 @@ impl WindowMethods for Window {
                     self.event_queue.borrow_mut().push(WindowEvent::Reload);
                 }
             }
+            (CMD_OR_CONTROL, Some('q'), _) => {
+                if let Some(true) = PREFS.get("shell.builtin-key-shortcuts.enabled").as_boolean() {
+                    self.event_queue.borrow_mut().push(WindowEvent::Quit);
+                }
+            }
 
             _ => {
                 self.platform_handle_key(key, mods);


### PR DESCRIPTION
Add a keyboard shortcut (Command + Q on Mac or Control + Q on other OS) to Quit the app directly. Fixes #12422